### PR TITLE
Add `~/.local/bin` to `PATH`

### DIFF
--- a/internal/assets/Dockerfile
+++ b/internal/assets/Dockerfile
@@ -3,6 +3,7 @@ FROM discourse/discourse_dev:release
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="~/.local/bin:$PATH"
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends vim ripgrep


### PR DESCRIPTION
Claude CLI installs the binary to `~/.local/bin` and adding `~/.loca/bin` to `PATH` is part of the post
installation instruction when installing claude CLI
