### PR TITLE
FEATURE: Add CLI commands for set/get site settings

### DIFF
--- a/internal/cli/config_set_site_setting.go
+++ b/internal/cli/config_set_site_setting.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"dv/internal/config"
+	"dv/internal/discourse"
+	"dv/internal/xdg"
+	"fmt"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+var setSiteSettingCommand = &cobra.Command{
+	Use:   "set-site-setting [setting] [value]",
+	Short: "Set an individual site setting value",
+	Args:  cobra.MaximumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		setting := args[0]
+		value := args[1]
+
+		// Load config and resolve container
+		configDir, err := xdg.ConfigDir()
+		if err != nil {
+			return err
+		}
+		cfg, err := config.LoadOrCreate(configDir)
+		if err != nil {
+			return err
+		}
+
+		containerOverride, _ := cmd.Flags().GetString("container")
+		containerName := strings.TrimSpace(containerOverride)
+		if containerName == "" {
+			containerName = currentAgentName(cfg)
+		}
+		if containerName == "" {
+			return fmt.Errorf("no container selected; run 'dv start' or pass --container")
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Setting site setting '%s' to '%s'...\n", setting, value)
+
+		client, err := discourse.NewClientWrapper(containerName, cfg, false)
+		if err != nil {
+			return fmt.Errorf("create discourse client: %w", err)
+		}
+		if err := client.EnsureAPIKey(); err != nil {
+			return fmt.Errorf("ensure API key: %w", err)
+		}
+
+		if err := client.SetSiteSetting(setting, value); err != nil {
+			return fmt.Errorf("error setting site setting: %w", err)
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Change was successful!\n")
+		return nil
+	},
+}
+
+func init() {
+	setSiteSettingCommand.Flags().String("setting", "", "Site setting name")
+	setSiteSettingCommand.Flags().String("value", "", "Site setting value")
+	setSiteSettingCommand.Flags().String("container", "", "Target container (defaults to selected agent)")
+	configCmd.AddCommand(setSiteSettingCommand)
+}

--- a/internal/cli/get_site_setting.go
+++ b/internal/cli/get_site_setting.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"dv/internal/config"
+	"dv/internal/discourse"
+	"dv/internal/xdg"
+	"fmt"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+var getSiteSettingCommand = &cobra.Command{
+	Use:   "get-site-setting [setting]",
+	Short: "Get an individual site setting value",
+	Args:  cobra.MaximumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		setting := args[0]
+
+		// Load config and resolve container
+		configDir, err := xdg.ConfigDir()
+		if err != nil {
+			return err
+		}
+		cfg, err := config.LoadOrCreate(configDir)
+		if err != nil {
+			return err
+		}
+
+		containerOverride, _ := cmd.Flags().GetString("container")
+		containerName := strings.TrimSpace(containerOverride)
+		if containerName == "" {
+			containerName = currentAgentName(cfg)
+		}
+		if containerName == "" {
+			return fmt.Errorf("no container selected; run 'dv start' or pass --container")
+		}
+
+		client, err := discourse.NewClientWrapper(containerName, cfg, false)
+		if err != nil {
+			return fmt.Errorf("create discourse client: %w", err)
+		}
+		if err := client.EnsureAPIKey(); err != nil {
+			return fmt.Errorf("ensure API key: %w", err)
+		}
+
+		currentValue, err := client.GetSiteSetting(setting)
+		if err != nil {
+			return fmt.Errorf("error getting site setting: %w", err)
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Current value for '%s' is '%s'\n", setting, currentValue)
+		return nil
+	},
+}
+
+func init() {
+	getSiteSettingCommand.Flags().String("setting", "", "Site setting name")
+	getSiteSettingCommand.Flags().String("container", "", "Target container (defaults to selected agent)")
+	configCmd.AddCommand(getSiteSettingCommand)
+}

--- a/internal/cli/restart.go
+++ b/internal/cli/restart.go
@@ -12,7 +12,7 @@ import (
 
 var restartCmd = &cobra.Command{
 	Use:   "restart [name]",
-	Short: "Restart the container",
+	Short: "Restart the container or internal discourse services (unicorn, ember-cli, etc.)",
 	Args:  cobra.MaximumNArgs(1),
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		// Complete container name for the first positional argument


### PR DESCRIPTION
Adds `dv config get-site-setting [name]` and
`dv config set-site-setting [name] [value]` commands to manage site settings via the CLI.

This is an easier way of interacting with individual settings rather than the more bulk `dv config site_settings` method.