### PR TITLE
FEATURE: Add extra pr and branch command flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ dv pr <TAB>
 Checkout a git branch in the container and reset the development environment.
 
 ```bash
-dv branch [--name NAME] BRANCH
+dv branch [--name NAME] [--no-reset] [--new] BRANCH
 ```
 
 Notes:
@@ -348,6 +348,8 @@ Notes:
 - Performs a full database reset and migration (development and test databases).
 - Reinstalls dependencies (bundle and pnpm).
 - Seeds test users.
+- Use `--no-reset` to skip DB reset and migrations (only checkout and reinstall deps).
+- Use `--new` to create a new branch from origin/main (or origin/master) if the branch does not exist on remote.
 - Supports TAB completion(e.g., `dv branch me<TAB>` queries only branches starting with "me").
 - Only works with containers using the `discourse` image kind.
 
@@ -361,6 +363,12 @@ dv branch <TAB>
 
 # Checkout a feature branch
 dv branch feature/my-feature
+
+# Create a new local branch for development
+dv branch --new my-new-feature
+
+# Quickly switch branches without resetting DB
+dv branch --no-reset main
 ```
 
 ### dv extract plugin

--- a/README.md
+++ b/README.md
@@ -316,14 +316,15 @@ dv extract --sync --debug
 Checkout a GitHub pull request in the container and reset the development environment.
 
 ```bash
-dv pr [--name NAME] NUMBER
+dv pr [--name NAME] [--no-reset] NUMBER
 ```
 
 Notes:
-- Fetches and checks out the specified PR into a local branch `pr-<NUMBER>`.
+- Fetches and checks out the specified PR into a local branch.
 - Performs a full database reset and migration (development and test databases).
 - Reinstalls dependencies (bundle and pnpm).
 - Seeds test users.
+- Use `--no-reset` to skip DB reset and migrations (only checkout and reinstall deps).
 - Supports TAB completion with PR numbers and titles from GitHub API.
 - Only works with containers using the `discourse` image kind.
 
@@ -331,6 +332,9 @@ Examples:
 ```bash
 # Checkout PR #12345
 dv pr 12345
+
+# Checkout without resetting DB
+dv pr --no-reset 12345
 
 # Use TAB completion to search and select a PR
 dv pr <TAB>

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Notes:
 - Performs a full database reset and migration (development and test databases).
 - Reinstalls dependencies (bundle and pnpm).
 - Seeds test users.
-- Use `--no-reset` to skip DB reset and migrations (only checkout and reinstall deps).
+- Use `--no-reset` to skip DB drop, create, and seed, but still run migrations reinstall deps.
 - Supports TAB completion with PR numbers and titles from GitHub API.
 - Only works with containers using the `discourse` image kind.
 
@@ -352,7 +352,7 @@ Notes:
 - Performs a full database reset and migration (development and test databases).
 - Reinstalls dependencies (bundle and pnpm).
 - Seeds test users.
-- Use `--no-reset` to skip DB reset and migrations (only checkout and reinstall deps).
+- Use `--no-reset` to skip DB drop, create, and seed, but still run migrations reinstall deps.
 - Use `--new` to create a new branch from origin/main (or origin/master) if the branch does not exist on remote.
 - Supports TAB completion(e.g., `dv branch me<TAB>` queries only branches starting with "me").
 - Only works with containers using the `discourse` image kind.

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -211,7 +211,7 @@ func checkoutPR(cmd *cobra.Command, cfg config.Config, name, workdir string, prN
 	}
 	branchName := prDetail.Head.Ref
 	checkoutCmds := buildPRCheckoutCommands(prNumber, branchName)
-	script := buildDiscourseResetScript(checkoutCmds)
+	script := buildDiscourseResetScript(checkoutCmds, discourseResetScriptOpts{})
 	return docker.ExecInteractive(name, workdir, envs, []string{"bash", "-lc", script})
 }
 
@@ -228,7 +228,7 @@ git pull > /tmp/dv-git-pull.log 2>&1
 		return docker.ExecInteractive(name, workdir, envs, []string{"bash", "-lc", script})
 	}
 	checkoutCmds := buildBranchCheckoutCommands(branchName)
-	script := buildDiscourseResetScript(checkoutCmds)
+	script := buildDiscourseResetScript(checkoutCmds, discourseResetScriptOpts{})
 	return docker.ExecInteractive(name, workdir, envs, []string{"bash", "-lc", script})
 }
 

--- a/internal/cli/pr.go
+++ b/internal/cli/pr.go
@@ -125,7 +125,7 @@ var prCmd = &cobra.Command{
 
 		// Build shell script to fetch and checkout PR branch using the actual branch name
 		checkoutCmds := buildPRCheckoutCommands(prNumber, branchName)
-		script := buildDiscourseResetScript(checkoutCmds)
+		script := buildDiscourseResetScript(checkoutCmds, discourseResetScriptOpts{})
 
 		// Run interactively to stream output to the user
 		argv := []string{"bash", "-lc", script}

--- a/internal/cli/reset.go
+++ b/internal/cli/reset.go
@@ -133,7 +133,7 @@ func resetGitRunE(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Resetting git and migrating in container '%s'...\n", name)
 
-	script := buildDiscourseResetScript(buildCurrentBranchResetCommands())
+	script := buildDiscourseResetScript(buildCurrentBranchResetCommands(), discourseResetScriptOpts{})
 	argv := []string{"bash", "-lc", script}
 	if err := docker.ExecInteractive(name, workdir, nil, argv); err != nil {
 		return fmt.Errorf("container: failed to reset git: %w", err)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -60,7 +60,8 @@ Additional help topics:
 {{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
 
-Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}`)
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`)
 
 	rootCmd.AddCommand(buildCmd)
 	rootCmd.AddCommand(startCmd)


### PR DESCRIPTION
* Adds --new to create a new branch that does not exist
  in remote and switches to it, using main as a base
* Adds --no-reset to circumvent DB drop+create+seed
  when switching branches and checking out prs

Both of these speed up dv workflow when using the same
container often for checking out other people's changes
or making small fixes.
