### PR TITLE
FEAT: add support for anthropic 3rd party models

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,9 @@ Automatically passed through when set on the host:
 - `GH_TOKEN`
 - `OPENROUTER_API_KEY`
 - `FACTORY_API_KEY`
+- `ANTHROPIC_DEFAULT_SONNET_MODEL`
+- `ANTHROPIC_DEFAULT_OPUS_MODEL`
+- `ANTHROPIC_DEFAULT_HAIKU_MODEL`
 
 ### Build acceleration toggles
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,6 +116,8 @@ func Default() Config {
 			"CLAUDE_CODE_USE_BEDROCK", "DEEPSEEK_API_KEY", "GEMINI_API_KEY",
 			"AMP_API_KEY", "GH_TOKEN", "OPENROUTER_API_KEY",
 			"FACTORY_API_KEY", "MISTRAL_API_KEY",
+			"ANTHROPIC_DEFAULT_SONNET_MODEL", "ANTHROPIC_DEFAULT_OPUS_MODEL",
+			"ANTHROPIC_DEFAULT_HAIKU_MODEL",
 		},
 		DiscourseRepo:       "https://github.com/discourse/discourse.git",
 		ExtractBranchPrefix: "agent-changes",


### PR DESCRIPTION
adds environment fallthrough for setting anthropic 3rd party model deployments.

see
https://code.claude.com/docs/en/model-config#pin-models-for-third-party-deployments