### PR TITLE
FEATURE: Support bind mounts via template

### DIFF
--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -206,10 +206,18 @@ var newCmd = &cobra.Command{
 		}
 		// initialize container by running a no-op command
 		var templateEnvs map[string]string
+		var templateMounts []docker.Mount
 		if tpl != nil {
 			templateEnvs = tpl.Env
+			for _, m := range tpl.Mounts {
+				templateMounts = append(templateMounts, docker.Mount{
+					Host:      m.Host,
+					Container: m.Container,
+					ReadOnly:  m.ReadOnly,
+				})
+			}
 		}
-		if err = ensureContainerRunningWithWorkdir(cmd, cfg, name, workdir, imageTag, imgName, false, sshAuthSock, templateEnvs); err != nil {
+		if err = ensureContainerRunningWithWorkdir(cmd, cfg, name, workdir, imageTag, imgName, false, sshAuthSock, templateEnvs, templateMounts); err != nil {
 			return err
 		}
 		containerCreated = true

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -289,7 +289,7 @@ func handleContainerCreate(w http.ResponseWriter, r *http.Request, configDir str
 				"DISCOURSE_PORT": strconv.Itoa(chosenPort),
 			}
 			logger(fmt.Sprintf("Creating and starting container '%s' with image '%s'...\n", name, imgCfg.Tag))
-			if err := docker.RunDetached(name, workdir, imgCfg.Tag, chosenPort, containerPort, labels, envs, nil, ""); err != nil {
+			if err := docker.RunDetached(name, workdir, imgCfg.Tag, chosenPort, containerPort, labels, envs, nil, "", nil); err != nil {
 				return err
 			}
 		} else if !docker.Running(name) {
@@ -452,7 +452,7 @@ func handleContainerStart(w http.ResponseWriter, r *http.Request, configDir, nam
 				"DISCOURSE_PORT": strconv.Itoa(chosenPort),
 			}
 			logger(fmt.Sprintf("Creating and starting container '%s'...\n", name))
-			return docker.RunDetached(name, workdir, imgCfg.Tag, chosenPort, cfg.ContainerPort, labels, envs, nil, "")
+			return docker.RunDetached(name, workdir, imgCfg.Tag, chosenPort, cfg.ContainerPort, labels, envs, nil, "", nil)
 		}
 		if !docker.Running(name) {
 			logger(fmt.Sprintf("Starting container '%s'...\n", name))

--- a/internal/cli/shared.go
+++ b/internal/cli/shared.go
@@ -389,10 +389,10 @@ func ensureContainerRunning(cmd *cobra.Command, cfg config.Config, name string, 
 	}
 	workdir := imgCfg.Workdir
 	imageTag := imgCfg.Tag
-	return ensureContainerRunningWithWorkdir(cmd, cfg, name, workdir, imageTag, imgName, reset, sshAuthSock, nil)
+	return ensureContainerRunningWithWorkdir(cmd, cfg, name, workdir, imageTag, imgName, reset, sshAuthSock, nil, nil)
 }
 
-func ensureContainerRunningWithWorkdir(cmd *cobra.Command, cfg config.Config, name string, workdir string, imageTag string, imgName string, reset bool, sshAuthSock string, templateEnvs map[string]string) error {
+func ensureContainerRunningWithWorkdir(cmd *cobra.Command, cfg config.Config, name string, workdir string, imageTag string, imgName string, reset bool, sshAuthSock string, templateEnvs map[string]string, templateMounts []docker.Mount) error {
 	if reset && docker.Exists(name) {
 		_ = docker.Stop(name)
 		_ = docker.Remove(name)
@@ -432,7 +432,7 @@ func ensureContainerRunningWithWorkdir(cmd *cobra.Command, cfg config.Config, na
 		if proxyHost != "" {
 			extraHosts = append(extraHosts, fmt.Sprintf("%s:127.0.0.1", proxyHost))
 		}
-		if err := docker.RunDetached(name, workdir, imageTag, chosenPort, cfg.ContainerPort, labels, envs, extraHosts, sshAuthSock); err != nil {
+		if err := docker.RunDetached(name, workdir, imageTag, chosenPort, cfg.ContainerPort, labels, envs, extraHosts, sshAuthSock, templateMounts); err != nil {
 			return err
 		}
 		if proxyHost != "" {

--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -111,7 +111,7 @@ var startCmd = &cobra.Command{
 			if proxyHost != "" {
 				extraHosts = append(extraHosts, fmt.Sprintf("%s:127.0.0.1", proxyHost))
 			}
-			if err := docker.RunDetached(name, workdir, imageTag, chosenPort, containerPort, labels, envs, extraHosts, ""); err != nil {
+			if err := docker.RunDetached(name, workdir, imageTag, chosenPort, containerPort, labels, envs, extraHosts, "", nil); err != nil {
 				return err
 			}
 
@@ -173,10 +173,10 @@ var startCmd = &cobra.Command{
 
 					// Recreate container with new port from snapshot
 					fmt.Fprintf(cmd.OutOrStdout(), "Recreating container with new port...\n")
-					if err := docker.RunDetached(name, existingWorkdir, tempImage, newPort, containerPort, labels, existingEnvs, nil, ""); err != nil {
+					if err := docker.RunDetached(name, existingWorkdir, tempImage, newPort, containerPort, labels, existingEnvs, nil, "", nil); err != nil {
 						// Try to restore from snapshot
 						fmt.Fprintf(cmd.ErrOrStderr(), "Failed to recreate, attempting restore...\n")
-						_ = docker.RunDetached(name, existingWorkdir, tempImage, existingPort, containerPort, labels, existingEnvs, nil, "")
+						_ = docker.RunDetached(name, existingWorkdir, tempImage, existingPort, containerPort, labels, existingEnvs, nil, "", nil)
 						_ = docker.RemoveImage(tempImage)
 						return fmt.Errorf("failed to recreate container: %w", err)
 					}

--- a/internal/cli/template.go
+++ b/internal/cli/template.go
@@ -20,6 +20,13 @@ type templateConfig struct {
 	Themes   []templateTheme   `yaml:"themes"`
 	Settings map[string]any    `yaml:"settings"`
 	MCP      []templateMCP     `yaml:"mcp"`
+	Mounts   []templateMount   `yaml:"mounts"`
+}
+
+type templateMount struct {
+	Host      string `yaml:"host"`
+	Container string `yaml:"container"`
+	ReadOnly  bool   `yaml:"read_only"`
 }
 
 type templatePlugin struct {

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -341,12 +341,81 @@ func ContainerIP(name string) (string, error) {
 	return ip, nil
 }
 
-func RunDetached(name, workdir, image string, hostPort, containerPort int, labels map[string]string, envs map[string]string, extraHosts []string, sshAuthSock string) error {
+// Mount describes a bind mount to apply when running a container.
+// Host paths may include ~ or $VAR and are expanded relative to the
+// invoking user's home directory.
+type Mount struct {
+	Host      string
+	Container string
+	ReadOnly  bool
+}
+
+// resolveMountHost expands ~ and environment variables in m.Host and
+// returns the effective host path. Returns "" when the mount should be
+// skipped entirely (either Host or Container is empty after expansion).
+// Pure function: no filesystem side effects.
+func resolveMountHost(m Mount, home string) string {
+	hostPath := m.Host
+	if strings.HasPrefix(hostPath, "~/") || hostPath == "~" {
+		hostPath = filepath.Join(home, strings.TrimPrefix(hostPath, "~"))
+	}
+	hostPath = os.ExpandEnv(hostPath)
+	if hostPath == "" || m.Container == "" {
+		return ""
+	}
+	return hostPath
+}
+
+// mountArgs returns the `-v` arguments to append to a docker run for the
+// given mounts. Pure function: no filesystem side effects.
+func mountArgs(mounts []Mount, home string) []string {
+	var args []string
+	for _, m := range mounts {
+		hostPath := resolveMountHost(m, home)
+		if hostPath == "" {
+			continue
+		}
+		spec := hostPath + ":" + m.Container
+		if m.ReadOnly {
+			spec += ":ro"
+		}
+		args = append(args, "-v", spec)
+	}
+	return args
+}
+
+// ensureMountHostPaths auto-creates any missing host directories so the
+// first run of a fresh project doesn't fail with "no such file or
+// directory". Existing paths (directory OR file) are left alone: docker
+// bind-mounts files to files just fine, and MkdirAll would fail on a
+// file. This is a deliberate convenience — a typo in a host path will
+// still create an empty directory and mount it, which mirrors docker's
+// own auto-create behaviour (docker creates missing host paths as root;
+// doing it here ensures the user owns them).
+func ensureMountHostPaths(mounts []Mount, home string) {
+	for _, m := range mounts {
+		hostPath := resolveMountHost(m, home)
+		if hostPath == "" {
+			continue
+		}
+		if _, err := os.Stat(hostPath); !os.IsNotExist(err) {
+			continue
+		}
+		if err := os.MkdirAll(hostPath, 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not create mount host path %s: %v\n", hostPath, err)
+		}
+	}
+}
+
+func RunDetached(name, workdir, image string, hostPort, containerPort int, labels map[string]string, envs map[string]string, extraHosts []string, sshAuthSock string, mounts []Mount) error {
 	args := []string{"run", "-d",
 		"--name", name,
 		"-w", workdir,
 		"-p", fmt.Sprintf("127.0.0.1:%d:%d", hostPort, containerPort),
 	}
+	home, _ := os.UserHomeDir()
+	ensureMountHostPaths(mounts, home)
+	args = append(args, mountArgs(mounts, home)...)
 	// hostSSHAuthSock tracks what SSH_AUTH_SOCK should be on the host for Docker to forward
 	hostSSHAuthSock := sshAuthSock
 	if sshAuthSock != "" {

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -280,3 +280,170 @@ func TestIsTruthyEnv(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveMountHost(t *testing.T) {
+	// Cannot t.Parallel(): one case uses t.Setenv which forbids parallel subtests.
+
+	const home = "/home/alice"
+	tests := []struct {
+		name  string
+		mount Mount
+		env   map[string]string
+		want  string
+	}{
+		{
+			name:  "tilde expansion",
+			mount: Mount{Host: "~/data", Container: "/data"},
+			want:  "/home/alice/data",
+		},
+		{
+			name:  "bare tilde",
+			mount: Mount{Host: "~", Container: "/h"},
+			want:  "/home/alice",
+		},
+		{
+			name:  "env var expansion",
+			mount: Mount{Host: "$WORKSPACE/cache", Container: "/cache"},
+			env:   map[string]string{"WORKSPACE": "/tmp/work"},
+			want:  "/tmp/work/cache",
+		},
+		{
+			name:  "absolute path passthrough",
+			mount: Mount{Host: "/etc/config", Container: "/etc/config"},
+			want:  "/etc/config",
+		},
+		{
+			name:  "empty host skipped",
+			mount: Mount{Host: "", Container: "/c"},
+			want:  "",
+		},
+		{
+			name:  "empty container skipped",
+			mount: Mount{Host: "/h", Container: ""},
+			want:  "",
+		},
+		{
+			name:  "tilde without slash is not expanded",
+			mount: Mount{Host: "~user/data", Container: "/c"},
+			want:  "~user/data",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			got := resolveMountHost(tt.mount, home)
+			if got != tt.want {
+				t.Errorf("resolveMountHost() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMountArgs(t *testing.T) {
+	t.Parallel()
+
+	const home = "/home/alice"
+	tests := []struct {
+		name   string
+		mounts []Mount
+		want   []string
+	}{
+		{
+			name:   "no mounts produces no args",
+			mounts: nil,
+			want:   nil,
+		},
+		{
+			name: "single read-write mount",
+			mounts: []Mount{
+				{Host: "/h", Container: "/c"},
+			},
+			want: []string{"-v", "/h:/c"},
+		},
+		{
+			name: "read_only adds :ro suffix",
+			mounts: []Mount{
+				{Host: "/h", Container: "/c", ReadOnly: true},
+			},
+			want: []string{"-v", "/h:/c:ro"},
+		},
+		{
+			name: "tilde-expanded host appears in spec",
+			mounts: []Mount{
+				{Host: "~/data", Container: "/data"},
+			},
+			want: []string{"-v", "/home/alice/data:/data"},
+		},
+		{
+			name: "empty fields skip the mount",
+			mounts: []Mount{
+				{Host: "", Container: "/c"},
+				{Host: "/h", Container: ""},
+				{Host: "/ok", Container: "/ok"},
+			},
+			want: []string{"-v", "/ok:/ok"},
+		},
+		{
+			name: "multiple mounts preserve order",
+			mounts: []Mount{
+				{Host: "/a", Container: "/x"},
+				{Host: "/b", Container: "/y", ReadOnly: true},
+			},
+			want: []string{"-v", "/a:/x", "-v", "/b:/y:ro"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mountArgs(tt.mounts, home)
+			if len(got) != len(tt.want) {
+				t.Fatalf("mountArgs() len = %d, want %d (got %v)", len(got), len(tt.want), got)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("mountArgs()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestEnsureMountHostPathsCreatesMissingDir(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	missing := filepath.Join(tmp, "auto", "created")
+	ensureMountHostPaths([]Mount{{Host: missing, Container: "/c"}}, "")
+	info, err := os.Stat(missing)
+	if err != nil {
+		t.Fatalf("expected %s to be created, got: %v", missing, err)
+	}
+	if !info.IsDir() {
+		t.Errorf("expected %s to be a directory", missing)
+	}
+}
+
+func TestEnsureMountHostPathsLeavesExistingFileAlone(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "config")
+	if err := os.WriteFile(file, []byte("data"), 0644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	ensureMountHostPaths([]Mount{{Host: file, Container: "/etc/config"}}, "")
+
+	info, err := os.Stat(file)
+	if err != nil {
+		t.Fatalf("file went missing: %v", err)
+	}
+	if info.IsDir() {
+		t.Errorf("expected %s to remain a file, became a directory", file)
+	}
+	contents, _ := os.ReadFile(file)
+	if string(contents) != "data" {
+		t.Errorf("file contents changed: got %q", contents)
+	}
+}


### PR DESCRIPTION
This commit adds a `mounts:` field to template YAML so bind mounts can be declared at `dv new` time. Without it, agents that need ongoing two-way access to host state had to round-trip via `dv cp` or build their own sync wrappers.

Each entry becomes a `-v <host>:<container>[:ro]` flag on the underlying `docker run`. Host paths support `~` and `$VAR` expansion, and missing host directories are created automatically. Non-template callers of `RunDetached` pass `nil` for the new mounts argument, so existing behaviour is unchanged.

Example template:

```yaml
git:
  ssh_forward: true

mounts:
  - host: ~/shared-workspace
    container: /home/discourse/shared-workspace
  - host: /etc/some-config
    container: /etc/some-config
    read_only: true
```