### PR TITLE
Add flag to skip test DB migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ dv rename old new                         # rename an agent
 Build the Docker image (defaults to tag `ai_agent`).
 
 ```bash
-dv build [--no-cache] [--build-arg KEY=VAL] [--rm-existing]
+dv build [--no-cache] [--build-arg KEY=VAL] [--rm-existing] [--without-test-db]
 ```
 
 Notes:
@@ -108,6 +108,7 @@ Notes:
   3) Embedded default (materialized to `${XDG_CONFIG_HOME}/dv/Dockerfile`)
   The command prints which Dockerfile path it used.
 - BuildKit/buildx is enabled by default (`docker buildx build --load`). The CLI automatically falls back to legacy `docker build` if buildx is unavailable.
+- Use `--without-test-db` to skip the stock image's test database migration at build time; the development database is still created and migrated.
 - Opt-out controls: `--classic-build` forces legacy `docker build`, and `--builder NAME` targets a specific buildx builder (remote builders, Docker Build Cloud, etc.).
 
 ### dv pull
@@ -299,6 +300,7 @@ Manage multiple containers for the selected image; selection is stored in XDG co
 ```bash
 dv list
 dv new [NAME]
+dv new --without-test-db fast-agent
 dv new --plugin discourse-kanban kanban
 dv new --plugin discourse/discourse-kanban kanban
 dv new --plugin git@github.com:my-org/private-plugin.git private-test
@@ -306,7 +308,7 @@ dv select NAME
 dv rename OLD NEW
 ```
 
-`dv new --plugin` creates a normal agent, then clones each requested plugin into the Discourse `plugins/` directory before running provisioning maintenance. `--plugin` is repeatable. Plugin arguments accept:
+`dv new --plugin` creates a normal agent, then clones each requested plugin into the Discourse `plugins/` directory before running provisioning maintenance. `--plugin` is repeatable. Pass `--without-test-db` to skip test database migration during new-agent provisioning when the agent only needs the development database. Plugin arguments accept:
 
 - `discourse-kanban` shorthand for `https://github.com/discourse/discourse-kanban.git`
 - `owner/repo` shorthand for `https://github.com/owner/repo.git`

--- a/internal/assets/Dockerfile
+++ b/internal/assets/Dockerfile
@@ -92,13 +92,18 @@ echo "All services ready!"
 EOF
 RUN chmod +x /tmp/wait-for-services.sh
 
+ARG WITHOUT_TEST_DB=0
 RUN /sbin/boot & \
     ( \
       set -e; \
       /tmp/wait-for-services.sh; \
       sudo -H -u discourse /bin/bash -lc 'cd /var/www/discourse && bin/rake db:create'; \
       sudo -H -u discourse /bin/bash -lc 'cd /var/www/discourse && bin/rake db:migrate'; \
-      sudo -H -u discourse /bin/bash -lc 'cd /var/www/discourse && RAILS_ENV=test bin/rake db:migrate'; \
+      if [ "$WITHOUT_TEST_DB" != "1" ]; then \
+        sudo -H -u discourse /bin/bash -lc 'cd /var/www/discourse && RAILS_ENV=test bin/rake db:migrate'; \
+      else \
+        echo "Skipping test database migration (WITHOUT_TEST_DB=1)"; \
+      fi; \
       sudo -H -u discourse /bin/bash -lc 'cd /var/www/discourse && bin/rails r /tmp/seed_users.rb' \
     ); \
     status=$?; \

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -71,14 +71,18 @@ var buildCmd = &cobra.Command{
 		removeExisting, _ := cmd.Flags().GetBool("rm-existing")
 		overrideTag, _ := cmd.Flags().GetString("tag")
 		disableBuildKit, _ := cmd.Flags().GetBool("classic-build")
+		withoutTestDB, _ := cmd.Flags().GetBool("without-test-db")
 		builderName, _ := cmd.Flags().GetString("builder")
 
-		pass := make([]string, 0, len(buildArgs)+1)
+		pass := make([]string, 0, len(buildArgs)+3)
 		if noCache {
 			pass = append(pass, "--no-cache")
 		}
 		for _, kv := range buildArgs {
 			pass = append(pass, "--build-arg", kv)
+		}
+		if withoutTestDB {
+			pass = append(pass, "--build-arg", "WITHOUT_TEST_DB=1")
 		}
 
 		if removeExisting && docker.Exists(cfg.DefaultContainer) {
@@ -171,5 +175,6 @@ func init() {
 	buildCmd.Flags().Bool("rm-existing", false, "Remove existing default container before building")
 	buildCmd.Flags().String("tag", "", "Override the Docker image tag for this build")
 	buildCmd.Flags().Bool("classic-build", false, "Use legacy 'docker build' instead of buildx/BuildKit helpers")
+	buildCmd.Flags().Bool("without-test-db", false, "Skip test database migration when building the image")
 	buildCmd.Flags().String("builder", "", "Specify a buildx builder (default: Docker's current builder)")
 }

--- a/internal/cli/discourse_reset.go
+++ b/internal/cli/discourse_reset.go
@@ -50,14 +50,24 @@ func buildDatabaseDropCreateMigrateCommands(opts discourseResetScriptOpts) []str
 		"echo 'Waiting for PostgreSQL to be ready...'",
 		"timeout 30 bash -c 'until pg_isready > /dev/null 2>&1; do sleep 1; done' || (echo 'PostgreSQL did not become ready'; exit 1)",
 		"MIG_LOG_DEV=/tmp/dv-migrate-dev-$(date +%s).log",
-		"MIG_LOG_TEST=/tmp/dv-migrate-test-$(date +%s).log",
+	}
+	if !opts.WithoutTestDB {
+		cmds = append(cmds, "MIG_LOG_TEST=/tmp/dv-migrate-test-$(date +%s).log")
 	}
 
 	if opts.SkipDBReset {
-		cmds = append(cmds, "echo 'Migrating databases (development and test)...'")
+		if opts.WithoutTestDB {
+			cmds = append(cmds, "echo 'Migrating development database...'")
+		} else {
+			cmds = append(cmds, "echo 'Migrating databases (development and test)...'")
+		}
 	} else {
+		if opts.WithoutTestDB {
+			cmds = append(cmds, "echo 'Resetting and migrating development database...'")
+		} else {
+			cmds = append(cmds, "echo 'Resetting and migrating databases (development and test)...'")
+		}
 		cmds = append(cmds,
-			"echo 'Resetting and migrating databases (development and test)...'",
 			"(bin/rake db:drop || true)",
 			"bin/rake db:create",
 		)
@@ -66,8 +76,14 @@ func buildDatabaseDropCreateMigrateCommands(opts discourseResetScriptOpts) []str
 	cmds = append(cmds,
 		"echo \"Migrating dev DB (output -> $MIG_LOG_DEV)\"",
 		"bin/rake db:migrate > \"$MIG_LOG_DEV\" 2>&1",
-		"echo \"Migrating test DB (output -> $MIG_LOG_TEST)\"",
-		"RAILS_ENV=test bin/rake db:migrate > \"$MIG_LOG_TEST\" 2>&1",
+	)
+	if !opts.WithoutTestDB {
+		cmds = append(cmds,
+			"echo \"Migrating test DB (output -> $MIG_LOG_TEST)\"",
+			"RAILS_ENV=test bin/rake db:migrate > \"$MIG_LOG_TEST\" 2>&1",
+		)
+	}
+	cmds = append(cmds,
 		"bundle",
 		"pnpm install",
 	)
@@ -84,16 +100,19 @@ func buildDatabaseDropCreateMigrateCommands(opts discourseResetScriptOpts) []str
 	cmds = append(cmds,
 		"echo 'Migration logs:'",
 		"echo \"  dev : $MIG_LOG_DEV\"",
-		"echo \"  test: $MIG_LOG_TEST\"",
-		"echo 'Done.'",
 	)
+	if !opts.WithoutTestDB {
+		cmds = append(cmds, "echo \"  test: $MIG_LOG_TEST\"")
+	}
+	cmds = append(cmds, "echo 'Done.'")
 
 	return cmds
 }
 
 // discourseResetScriptOpts configures buildDiscourseResetScript.
 type discourseResetScriptOpts struct {
-	SkipDBReset bool // if true, only migrate databases, do not drop or create them
+	SkipDBReset   bool // if true, only migrate databases, do not drop or create them
+	WithoutTestDB bool // if true, skip test database migration
 }
 
 // buildDiscourseResetScript generates a shell script that performs common

--- a/internal/cli/discourse_reset_test.go
+++ b/internal/cli/discourse_reset_test.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildDatabaseDropCreateMigrateCommands_WithoutTestDB(t *testing.T) {
+	t.Parallel()
+
+	cmds := buildDatabaseDropCreateMigrateCommands(discourseResetScriptOpts{WithoutTestDB: true})
+	script := strings.Join(cmds, "\n")
+
+	if !strings.Contains(script, "bin/rake db:migrate") {
+		t.Fatal("missing development database migration")
+	}
+	if strings.Contains(script, "RAILS_ENV=test") {
+		t.Fatalf("test database migration should be omitted:\n%s", script)
+	}
+	if strings.Contains(script, "MIG_LOG_TEST") {
+		t.Fatalf("test migration log should be omitted:\n%s", script)
+	}
+}
+
+func TestBuildMaintenanceScript_WithoutTestDB(t *testing.T) {
+	t.Parallel()
+
+	script := buildMaintenanceScript(true)
+
+	if !strings.Contains(script, "bin/rake db:migrate") {
+		t.Fatal("missing development database migration")
+	}
+	if strings.Contains(script, "RAILS_ENV=test") {
+		t.Fatalf("test database migration should be omitted:\n%s", script)
+	}
+	if strings.Contains(script, "dv-migrate-test.log") {
+		t.Fatalf("test migration log should be omitted:\n%s", script)
+	}
+}
+
+func TestBuildMaintenanceScript_WithTestDB(t *testing.T) {
+	t.Parallel()
+
+	script := buildMaintenanceScript(false)
+
+	if !strings.Contains(script, "bin/rake db:migrate") {
+		t.Fatal("missing development database migration")
+	}
+	if !strings.Contains(script, "RAILS_ENV=test bin/rake db:migrate") {
+		t.Fatal("missing test database migration")
+	}
+}

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -185,6 +185,8 @@ var newCmd = &cobra.Command{
 		}
 
 		// Apply template-specific config changes before saving
+		withoutTestDB, _ := cmd.Flags().GetBool("without-test-db")
+
 		if tpl != nil {
 			// Add copy rules
 			for _, rule := range tpl.Copy {
@@ -243,7 +245,7 @@ var newCmd = &cobra.Command{
 				tpl.Discourse.Branch = branchFlag
 			}
 
-			if err = executeTemplate(cmd, cfg, name, workdir, tpl, sshAuthSock, verbose); err != nil {
+			if err = executeTemplate(cmd, cfg, name, workdir, tpl, sshAuthSock, verbose, withoutTestDB); err != nil {
 				return err
 			}
 		}
@@ -263,7 +265,7 @@ func confirmInvalidRailsHostname(cmd *cobra.Command, name string) (bool, error) 
 	return promptYesNo(cmd.InOrStdin(), errOut, "Continue anyway? (y/N): ")
 }
 
-func checkoutPR(cmd *cobra.Command, cfg config.Config, name, workdir string, prNumber int, envs docker.Envs) error {
+func checkoutPR(cmd *cobra.Command, cfg config.Config, name, workdir string, prNumber int, envs docker.Envs, withoutTestDB bool) error {
 	owner, repo := prSearchOwnerRepoFromContainer(cfg, name)
 	if owner == "" || repo == "" {
 		owner, repo = ownerRepoFromURL(cfg.DiscourseRepo)
@@ -277,7 +279,7 @@ func checkoutPR(cmd *cobra.Command, cfg config.Config, name, workdir string, prN
 	}
 	branchName := prDetail.Head.Ref
 	checkoutCmds := buildPRCheckoutCommands(prNumber, branchName)
-	script := buildDiscourseResetScript(checkoutCmds, discourseResetScriptOpts{})
+	script := buildDiscourseResetScript(checkoutCmds, discourseResetScriptOpts{WithoutTestDB: withoutTestDB})
 	return docker.ExecInteractive(name, workdir, envs, []string{"bash", "-lc", script})
 }
 
@@ -311,7 +313,7 @@ git reset --hard "origin/$_branch"
 	return docker.ExecInteractive(name, workdir, envs, []string{"bash", "-lc", script})
 }
 
-func checkoutBranch(cmd *cobra.Command, cfg config.Config, name, workdir, branchName string, envs docker.Envs) error {
+func checkoutBranch(cmd *cobra.Command, cfg config.Config, name, workdir, branchName string, envs docker.Envs, withoutTestDB bool) error {
 	if branchName == "main" || branchName == "master" {
 		fmt.Fprintf(cmd.OutOrStdout(), "Updating %s branch...\n", branchName)
 		assetClobberCmds := strings.Join(buildAssetsClobberCommands(), "\n")
@@ -326,7 +328,7 @@ git pull > /tmp/dv-git-pull.log 2>&1
 		return docker.ExecInteractive(name, workdir, envs, []string{"bash", "-lc", script})
 	}
 	checkoutCmds := buildBranchCheckoutCommands(branchName)
-	script := buildDiscourseResetScript(checkoutCmds, discourseResetScriptOpts{})
+	script := buildDiscourseResetScript(checkoutCmds, discourseResetScriptOpts{WithoutTestDB: withoutTestDB})
 	return docker.ExecInteractive(name, workdir, envs, []string{"bash", "-lc", script})
 }
 
@@ -341,33 +343,46 @@ func uniqueAgentName(base string) string {
 	return name
 }
 
-func runMaintenance(cmd *cobra.Command, name, workdir string, envList docker.Envs) error {
+func runMaintenance(cmd *cobra.Command, name, workdir string, envList docker.Envs, withoutTestDB bool) error {
 	fmt.Fprintf(cmd.OutOrStdout(), "Running maintenance (bundle, migrate)...\n")
-	script := `
-set -e
-trap 'echo "Error occurred. Check $FAILED_LOG inside the container for details."; exit 1' ERR
-
-echo "Bundling..."
-FAILED_LOG=/tmp/dv-bundle.log
-bundle install > $FAILED_LOG 2>&1
-
-echo "Waiting for PostgreSQL to be ready..."
-timeout 30 bash -c 'until pg_isready > /dev/null 2>&1; do sleep 1; done' || (echo "PostgreSQL did not become ready"; exit 1)
-
-echo "Migrating dev..."
-FAILED_LOG=/tmp/dv-migrate-dev.log
-bin/rake db:migrate > $FAILED_LOG 2>&1
-
-echo "Migrating test..."
-FAILED_LOG=/tmp/dv-migrate-test.log
-RAILS_ENV=test bin/rake db:migrate > $FAILED_LOG 2>&1
-
-echo "Maintenance successful."
-`
+	script := buildMaintenanceScript(withoutTestDB)
 	return docker.ExecInteractive(name, workdir, envList, []string{"bash", "-lc", script})
 }
 
-func executeTemplate(cmd *cobra.Command, cfg config.Config, name, workdir string, tpl *templateConfig, sshAuthSock string, verbose bool) (err error) {
+func buildMaintenanceScript(withoutTestDB bool) string {
+	lines := []string{
+		"set -e",
+		"trap 'echo \"Error occurred. Check $FAILED_LOG inside the container for details.\"; exit 1' ERR",
+		"",
+		"echo \"Bundling...\"",
+		"FAILED_LOG=/tmp/dv-bundle.log",
+		"bundle install > $FAILED_LOG 2>&1",
+		"",
+		"echo \"Waiting for PostgreSQL to be ready...\"",
+		"timeout 30 bash -c 'until pg_isready > /dev/null 2>&1; do sleep 1; done' || (echo \"PostgreSQL did not become ready\"; exit 1)",
+		"",
+		"echo \"Migrating dev...\"",
+		"FAILED_LOG=/tmp/dv-migrate-dev.log",
+		"bin/rake db:migrate > $FAILED_LOG 2>&1",
+	}
+
+	if !withoutTestDB {
+		lines = append(lines,
+			"",
+			"echo \"Migrating test...\"",
+			"FAILED_LOG=/tmp/dv-migrate-test.log",
+			"RAILS_ENV=test bin/rake db:migrate > $FAILED_LOG 2>&1",
+		)
+	}
+
+	lines = append(lines,
+		"",
+		"echo \"Maintenance successful.\"",
+	)
+	return strings.Join(lines, "\n")
+}
+
+func executeTemplate(cmd *cobra.Command, cfg config.Config, name, workdir string, tpl *templateConfig, sshAuthSock string, verbose bool, withoutTestDB bool) (err error) {
 	// 1. Env variables
 	envList := collectEnvPassthrough(cfg)
 	if len(tpl.Env) > 0 {
@@ -396,7 +411,7 @@ func executeTemplate(cmd *cobra.Command, cfg config.Config, name, workdir string
 	}
 	if tpl.Discourse.PR != 0 {
 		fmt.Fprintf(cmd.OutOrStdout(), "Checking out PR %d...\n", tpl.Discourse.PR)
-		if err := checkoutPR(cmd, cfg, name, workdir, tpl.Discourse.PR, envList); err != nil {
+		if err := checkoutPR(cmd, cfg, name, workdir, tpl.Discourse.PR, envList, withoutTestDB); err != nil {
 			return err
 		}
 	} else if tpl.Discourse.Branch != "" {
@@ -406,7 +421,7 @@ func executeTemplate(cmd *cobra.Command, cfg config.Config, name, workdir string
 			}
 		} else {
 			fmt.Fprintf(cmd.OutOrStdout(), "Checking out branch %s...\n", tpl.Discourse.Branch)
-			if err := checkoutBranch(cmd, cfg, name, workdir, tpl.Discourse.Branch, envList); err != nil {
+			if err := checkoutBranch(cmd, cfg, name, workdir, tpl.Discourse.Branch, envList, withoutTestDB); err != nil {
 				return err
 			}
 		}
@@ -444,7 +459,7 @@ func executeTemplate(cmd *cobra.Command, cfg config.Config, name, workdir string
 
 	// 5. Maintenance (Bundle and Migrate)
 	// Now that core is foundation-ed and plugins are cloned, we bundle and migrate.
-	if err := runMaintenance(cmd, name, workdir, envList); err != nil {
+	if err := runMaintenance(cmd, name, workdir, envList, withoutTestDB); err != nil {
 		return err
 	}
 
@@ -571,6 +586,7 @@ func init() {
 	newCmd.Flags().String("pr", "", "PR number or search query to checkout")
 	newCmd.Flags().String("branch", "", "Branch to checkout")
 	newCmd.Flags().StringArray("plugin", nil, "Clone plugin into the new agent (NAME, OWNER/REPO, or git URL; repeatable)")
+	newCmd.Flags().Bool("without-test-db", false, "Skip test database migration during provisioning")
 
 	newCmd.RegisterFlagCompletionFunc("pr", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		configDir, err := xdg.ConfigDir()

--- a/internal/cli/plugin.go
+++ b/internal/cli/plugin.go
@@ -72,7 +72,7 @@ PLUGIN accepts:
 			}
 
 			if !skipMaintenance {
-				if err := runMaintenance(cmd, ctx.name, ctx.workdir, envs); err != nil {
+				if err := runMaintenance(cmd, ctx.name, ctx.workdir, envs, false); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
## Summary
- add `dv build --without-test-db` to skip the stock image test DB migration via a Docker build arg
- add `dv new --without-test-db` so new-agent provisioning, PR/branch resets, and maintenance skip test DB migrations
- document the flag and cover the migration-script behavior with tests

## Tests
- `go test ./...`