### PR TITLE
PERF: Skip Discourse readiness wait when no post-boot steps need it

### DIFF
--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -463,19 +463,31 @@ func executeTemplate(cmd *cobra.Command, cfg config.Config, name, workdir string
 		return err
 	}
 
-	// 6. Start Services and Wait for Health
-	fmt.Fprintf(cmd.OutOrStdout(), "Provisioning complete. Starting Discourse and waiting for it to be ready...\n")
+	// 6. Start Services
+	// Only block on the HTTP health check when a later step needs a live
+	// Rails/API (site settings, themes, on_create commands, MCP). With none of
+	// those, the wait is dead time: services are started either way and finish
+	// booting in the background.
+	needsHealth := len(tpl.Settings) > 0 || len(tpl.Themes) > 0 || len(tpl.OnCreate) > 0 || len(tpl.MCP) > 0
+	if needsHealth {
+		fmt.Fprintf(cmd.OutOrStdout(), "Provisioning complete. Starting Discourse and waiting for it to be ready...\n")
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(), "Provisioning complete. Starting Discourse...\n")
+	}
 	startScript := "sudo /usr/bin/sv start rails ember || true"
 	if _, err = docker.ExecOutput(name, workdir, nil, []string{"bash", "-lc", startScript}); err != nil {
 		return fmt.Errorf("failed to start services: %w", err)
 	}
 
-	// Wait for health check (max 120s) — hit Rails directly.
-	healthCmd := "timeout 120 bash -c 'until curl -s -f http://localhost:3000/srv/status > /dev/null 2>&1; do sleep 2; done' || exit 1"
-	if _, err = docker.ExecOutput(name, workdir, nil, []string{"bash", "-lc", healthCmd}); err != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Discourse did not become healthy within 120s. Some settings might fail.\n")
-	} else {
-		fmt.Fprintf(cmd.OutOrStdout(), "Discourse is ready.\n")
+	// Wait for health check (max 120s) only when a subsequent step requires it.
+	if needsHealth {
+		// Hit Rails directly.
+		healthCmd := "timeout 120 bash -c 'until curl -s -f http://localhost:3000/srv/status > /dev/null 2>&1; do sleep 2; done' || exit 1"
+		if _, err = docker.ExecOutput(name, workdir, nil, []string{"bash", "-lc", healthCmd}); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Discourse did not become healthy within 120s. Some settings might fail.\n")
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "Discourse is ready.\n")
+		}
 	}
 
 	// 8. Post-Boot Configuration (Settings, Themes, MCP)


### PR DESCRIPTION
When `dv new` runs with a template (or `--pr`/`--branch`, which synthesize one), it starts Discourse's services and then waits for the web server to answer an HTTP health check on `/srv/status`, up to a 120s timeout. Without a template, `dv new` creates the container and returns without running this step. The wait only matters when a later step in the template flow needs a running Rails or web server: applying site settings, installing themes, running `on_create` commands, or configuring MCP. For a template that declares none of those, the check adds delay without affecting the result, since the services are started regardless and continue booting on their own.

This commit makes the readiness check conditional on the template defining at least one of those post-boot steps. Templates that have them are unchanged and still print `Discourse is ready.` once the server responds. Templates that have none skip the wait and return as soon as the services are started.