### PR TITLE
fix(start): preserve bind mounts when auto-remapping container port

### DIFF
--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -151,6 +151,7 @@ var startCmd = &cobra.Command{
 						existingWorkdir = workdir
 					}
 					existingEnvs, _ := docker.GetContainerEnv(name)
+					existingMounts, _ := docker.GetContainerMounts(name)
 
 					// Commit container to temporary image
 					tempImage := name + "-dv-snapshot"
@@ -171,12 +172,14 @@ var startCmd = &cobra.Command{
 					}
 					existingEnvs["DISCOURSE_PORT"] = fmt.Sprintf("%d", newPort)
 
-					// Recreate container with new port from snapshot
+					// Recreate container with new port from snapshot. Re-apply the
+					// existing bind mounts (the snapshot bakes the filesystem but
+					// not mount specs) so a mounted plugin isn't silently dropped.
 					fmt.Fprintf(cmd.OutOrStdout(), "Recreating container with new port...\n")
-					if err := docker.RunDetached(name, existingWorkdir, tempImage, newPort, containerPort, labels, existingEnvs, nil, "", nil); err != nil {
+					if err := docker.RunDetached(name, existingWorkdir, tempImage, newPort, containerPort, labels, existingEnvs, nil, "", existingMounts); err != nil {
 						// Try to restore from snapshot
 						fmt.Fprintf(cmd.ErrOrStderr(), "Failed to recreate, attempting restore...\n")
-						_ = docker.RunDetached(name, existingWorkdir, tempImage, existingPort, containerPort, labels, existingEnvs, nil, "", nil)
+						_ = docker.RunDetached(name, existingWorkdir, tempImage, existingPort, containerPort, labels, existingEnvs, nil, "", existingMounts)
 						_ = docker.RemoveImage(tempImage)
 						return fmt.Errorf("failed to recreate container: %w", err)
 					}

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -1033,3 +1033,39 @@ func GetContainerEnv(name string) (map[string]string, error) {
 	}
 	return envMap, nil
 }
+
+// GetContainerMounts returns the bind mounts of an existing container, read back
+// via `docker inspect`. Used when recreating a container (e.g. an automatic port
+// remap) so user-declared bind mounts are preserved alongside the workdir and
+// env that are already recovered the same way. Anonymous/named volumes and the
+// forwarded SSH agent socket (re-established separately) are excluded.
+func GetContainerMounts(name string) ([]Mount, error) {
+	out, err := exec.Command("docker", "inspect", "-f", "{{json .Mounts}}", name).Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseContainerMounts(out)
+}
+
+func parseContainerMounts(data []byte) ([]Mount, error) {
+	var raw []struct {
+		Type        string `json:"Type"`
+		Source      string `json:"Source"`
+		Destination string `json:"Destination"`
+		RW          bool   `json:"RW"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	var mounts []Mount
+	for _, m := range raw {
+		// Only re-apply host bind mounts; anonymous/named volumes are managed by
+		// docker. Skip the forwarded SSH agent socket (see RunDetached) — it is
+		// re-established via the sshAuthSock path, not as a persisted bind mount.
+		if m.Type != "bind" || m.Destination == "/tmp/ssh-agent.sock" {
+			continue
+		}
+		mounts = append(mounts, Mount{Host: m.Source, Container: m.Destination, ReadOnly: !m.RW})
+	}
+	return mounts, nil
+}

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -447,3 +447,42 @@ func TestEnsureMountHostPathsLeavesExistingFileAlone(t *testing.T) {
 		t.Errorf("file contents changed: got %q", contents)
 	}
 }
+
+func TestParseContainerMounts(t *testing.T) {
+	t.Parallel()
+
+	input := `[
+	  {"Type":"bind","Source":"/Users/a/work/plugin","Destination":"/var/www/discourse/plugins/p","RW":true},
+	  {"Type":"bind","Source":"/etc/cfg","Destination":"/etc/cfg","RW":false},
+	  {"Type":"bind","Source":"/run/host-services/ssh-auth.sock","Destination":"/tmp/ssh-agent.sock","RW":true},
+	  {"Type":"volume","Source":"/var/lib/docker/volumes/x/_data","Destination":"/data","RW":true}
+	]`
+
+	got, err := parseContainerMounts([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []Mount{
+		{Host: "/Users/a/work/plugin", Container: "/var/www/discourse/plugins/p", ReadOnly: false},
+		{Host: "/etc/cfg", Container: "/etc/cfg", ReadOnly: true},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d mounts, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("mount %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParseContainerMountsEmpty(t *testing.T) {
+	t.Parallel()
+	got, err := parseContainerMounts([]byte(`[]`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected no mounts, got %+v", got)
+	}
+}


### PR DESCRIPTION
When the host port is taken, `dv start` transparently remaps to a free port by recreating the container (snapshot → remove → run). It recovers the container's workdir and env via `docker inspect` but passed `nil` mounts, so a bind-mounted directory like a plugin silently came back as the empty baked-in copy — `docker commit` preserves the filesystem layer but not mount specs.

This adds `docker.GetContainerMounts`, a sibling of the existing `GetContainerWorkdir`/`GetContainerEnv` inspect helpers, and re-applies the container's bind mounts on both the recreate and restore paths; anonymous/named volumes and the forwarded SSH socket are excluded. Scope is limited to the silent auto-remap path — explicit `dv start --reset` and serve resets already reset env/workdir to image defaults, so mounts intentionally aren't carried across them.

Build/vet/gofmt/tests pass; adds `TestParseContainerMounts` covering bind/volume filtering, the SSH-socket exclusion, and read-only mapping.